### PR TITLE
added isset check for response in PaymentException __construct method

### DIFF
--- a/src/Exception/PaymentException.php
+++ b/src/Exception/PaymentException.php
@@ -21,9 +21,15 @@ class PaymentException extends BaseException
 
     public function __construct($response)
     {
-        $this->reason = $response['Model']['Reason'];
-        $this->reasonCode = $response['Model']['ReasonCode'];
-        $this->cardHolderMessage = $response['Model']['CardHolderMessage'];
+        $this->reason = null;
+        $this->reasonCode = null;
+        $this->cardHolderMessage = null;
+
+        if(isset($response['Model'])) {
+            if(isset($response['Model']['Reason'])) $this->reason = $response['Model']['Reason'];
+            if(isset($response['Model']['ReasonCode'])) $this->reasonCode = $response['Model']['ReasonCode'];
+            if(isset($response['Model']['CardHolderMessage'])) $this->cardHolderMessage = $response['Model']['CardHolderMessage'];
+        }
 
         parent::__construct($this->reason);
     }


### PR DESCRIPTION
response от CP не всегда содержит поле Reason (например, при недостаточном количестве денег на карте). Соответственно, при вызове конструктора PaymentException происходит обращение к несуществующему индексу response['Model']['Reason'].